### PR TITLE
Make sure any whitespace of \n characters are removed from filepaths.

### DIFF
--- a/src/Psecio/Iniscan/Scan.php
+++ b/src/Psecio/Iniscan/Scan.php
@@ -145,7 +145,8 @@ class Scan
 		$scannedIniList = php_ini_scanned_files();
 		if ($scannedIniList !== false) {
 			foreach(explode(',', $scannedIniList) as $scannedFile) {
-				$scannedIni = parse_ini_file($scannedFile);
+                $filePath = trim($scannedFile);
+				$scannedIni = parse_ini_file($filePath);
 				$ini = array_merge($ini, $scannedIni);
 			}
 		}


### PR DESCRIPTION
Fixes the problem whereby ini files that are symlinks cannot be parsed on Ubuntu.
