### PR TITLE
Make sure '0' get cast as 0 in operation cast

### DIFF
--- a/src/Psecio/Iniscan/Operation.php
+++ b/src/Psecio/Iniscan/Operation.php
@@ -82,7 +82,7 @@ abstract class Operation
 	 */
 	public function castValue($value)
 	{
-		if ($value === 'Off' || $value === '' || $value === 0) {
+		if ($value === 'Off' || $value === '' || $value === 0 || $value == '0') {
 			$casted = 0;
 		} elseif ($value === 'On' || $value === '1' || $value === 1) {
 			$casted = 1;

--- a/tests/Psecio/Iniscan/OperationTest.php
+++ b/tests/Psecio/Iniscan/OperationTest.php
@@ -9,7 +9,7 @@ class OperationTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * Test the "casting" of a value to a consistent output
 	 * given a string
-	 * 
+	 *
 	 * @covers \Psecio\Iniscan\Operation::castValue
 	 */
     public function testCastValueString()
@@ -25,12 +25,44 @@ class OperationTest extends \PHPUnit_Framework_TestCase
     /**
 	 * Test the "casting" of a value to a consistent output
 	 * given an integer
-	 * 
+	 *
 	 * @covers \Psecio\Iniscan\Operation::castValue
 	 */
     public function testCastValueInteger()
     {
     	$input = 1;
+        $operation = new OperationStub('test');
+        $result = $operation->castValue($input);
+
+        $this->assertEquals($result, 1);
+        $this->assertEquals(gettype($result), 'integer');
+    }
+
+	/**
+	 * Test the "casting" of a value to a consistent output
+	 * given number 0 as a string
+	 *
+	 * @covers \Psecio\Iniscan\Operation::castValue
+	 */
+    public function testCastValueNumberAsString()
+    {
+        $input = '0';
+        $operation = new OperationStub('test');
+        $result = $operation->castValue($input);
+
+        $this->assertEquals($result, 0);
+        $this->assertEquals(gettype($result), 'integer');
+    }
+
+	/**
+	 * Test the "casting" of a value to a consistent output
+	 * given number 1 as a string
+	 *
+	 * @covers \Psecio\Iniscan\Operation::castValue
+	 */
+    public function testCastValueNumber1AsString()
+    {
+        $input = '1';
         $operation = new OperationStub('test');
         $result = $operation->castValue($input);
 


### PR DESCRIPTION
On my laptop, when setting key = Off, the cast function received '0' and it was returning that value instead of 0.
