### PR TITLE
Force usage of cookie_secure

### DIFF
--- a/src/Psecio/Iniscan/rules.json
+++ b/src/Psecio/Iniscan/rules.json
@@ -47,6 +47,16 @@
 							"operation": "equals",
 							"value": "0"
 						}
+					},
+					{
+						"name": "Cookie set to secure connection",
+						"description": "Cookie secure specifies whether cookies should only be sent over secure connections.",
+						"level": "ERROR",
+						"test": {
+							"key": "session.cookie_secure",
+							"operation": "equals",
+							"value": "1"
+						}
 					}
 				],
 				"PHP": [


### PR DESCRIPTION
Cookie connection should be forced to secure connection, see also OWASP recommendation about that: https://www.owasp.org/index.php/PHP_Configuration_Cheat_Sheet
