### PR TITLE
Don't overwrite the default `list` command as defined by the Symfony Con...

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ vendor/bin/iniscan show --path=/path/to/php.ini
 
 ##### List
 
-The `list` command shows a listing of the current rules being checked and their related php.ini key.
+The `list-tests` command shows a listing of the current rules being checked and their related php.ini key.
 
 ```
-vendor/bin/iniscan list
+vendor/bin/iniscan list-tests
 ```
 
 #### Output formats
@@ -112,10 +112,10 @@ By default *iniscan* will output information directly to the console in a human-
 vendor/bin/iniscan show --path=/path/to/php.ini --format=json
 ```
 
-the `list` command also supports JSON output:
+the `list-tests` command also supports JSON output:
 
 ```
-vendor/bin/iniscan list --path=/path/to/php.ini --format=json
+vendor/bin/iniscan list-tests --path=/path/to/php.ini --format=json
 ```
 
 **NOTE:** Currently, only the `scan` command supports alternate output formats - and only three: console, JSON and XML.

--- a/src/Psecio/Iniscan/Command/ListCommand.php
+++ b/src/Psecio/Iniscan/Command/ListCommand.php
@@ -10,7 +10,7 @@ class ListCommand extends Command
 {
     protected function configure()
     {
-        $this->setName('list')
+        $this->setName('list-tests')
             ->setDescription('Output information about the current rule checks')
             ->setDefinition(array(
                 new InputOption('format', 'format', InputOption::VALUE_OPTIONAL, 'Output format'),
@@ -23,8 +23,9 @@ class ListCommand extends Command
     /**
      * Execute the "list" command
      *
-     * @param  InputInterface  $input  Input object
+     * @param  InputInterface $input Input object
      * @param  OutputInterface $output Output object
+     * @throws \Psecio\Iniscan\Exceptions\FormatNotFoundException
      * @return null
      */
     protected function execute(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
...sole component.

Normally when you run a Symfony Console application without any arguments it shows a nice list of all available commands.

Because the `list` command overwrote this default command it was not possible to get the helpfull list of commands.

This pull request solves this by renaming `list` to `list-tests`.
