### PR TITLE
The Display Errors Rule is back to front

### DIFF
--- a/src/Psecio/Iniscan/rules.json
+++ b/src/Psecio/Iniscan/rules.json
@@ -96,7 +96,7 @@
 						"level": "WARNING",
 						"test": {
 							"key": "display_errors",
-							"operation": "notequals",
+							"operation": "equals",
 							"value": "0",
 							"context": ["prod"]
 						}


### PR DESCRIPTION
Just downloaded and gave iniscan a whirl.

I discovered the display_errors rule is back to front.

My display_errors is set to off, but the scan reported it as a fail.
This PR just flips the equals/notequals
