### PR TITLE
Small fixes for the entropy check

### DIFF
--- a/src/Psecio/Iniscan/Rule/CheckSessionEntropyPath.php
+++ b/src/Psecio/Iniscan/Rule/CheckSessionEntropyPath.php
@@ -2,8 +2,10 @@
 namespace Psecio\Iniscan\Rule;
 
 /**
- * Custom operation - Checks to see if the maximum
- * 	post size is too large
+ * Custom operation - Checks to see if a session entropy file is provided
+ *
+ * http://php.net/manual/en/session.configuration.php#ini.session.entropy-file
+ * As of PHP 5.4.0 session.entropy_file defaults to /dev/urandom or /dev/arandom if it is available.
  */
 class CheckSessionEntropyPath extends \Psecio\Iniscan\Rule
 {
@@ -15,11 +17,9 @@ class CheckSessionEntropyPath extends \Psecio\Iniscan\Rule
 
 	public function evaluate(array $ini)
 	{
-		$entropyFile = $ini['Session']['session.entropy_file'];
-
 		// If the version is less than 5.4.0
-		if (version_compare(PHP_VERSION, '5.4.0', '<') === true) {
-			if ($entropyFile === '') {
+		if (version_compare($this->getVersion(), '5.4.0', '<') === true) {
+			if (empty($ini['Session']['session.entropy_file'])) {
 				$this->fail();
 				return false;
 			}


### PR DESCRIPTION
Fix for the entropy check:
- Updated Entropy check to not throw a warning if the value is not set. (PHP Notice:  Undefined index: session.entropy_file in [file])
- Changed check to use the getVersion() call to comply with the version passing added (defaults to current version).
- Updated file comment
