### PR TITLE
Added rules to check if Xdebug is enabled or not

### DIFF
--- a/src/Psecio/Iniscan/rules.json
+++ b/src/Psecio/Iniscan/rules.json
@@ -338,6 +338,30 @@
 						}
 					}
 				],
+				"Extensions": [
+                    {
+                        "name": "Ensure that Xdebug is disabled",
+                        "description": "Xdebug should be disabled in production",
+                        "level": "WARNING",
+                        "test": {
+                            "key": "xdebug.default_enable",
+                            "operation": "equals",
+                            "value": "0",
+                            "context": ["prod"]
+                        }
+                    },
+                    {
+                        "name": "Ensure that Xdebug is not waiting for a debug client",
+                        "description": "Xdebug should not be trying to contact debug clients",
+                        "level": "WARNING",
+                        "test": {
+                            "key": "xdebug.remote_enable",
+                            "operation": "equals",
+                            "value": "0",
+                            "context": ["prod"]
+                        }
+                    }
+                ],
 				"Custom": [
 					{
 						"name": "Disable harmful CLI functions",


### PR DESCRIPTION
To fix #69 I just added two rules to check if **xdebug.default_enable** and **xdebug.remote_enable** are disabled.

There are more things that can be disabled, but, as they concern performance instead of security I did not add them, if it's ok I can add them, one example would be **xdebug.profiler_enable**.
