### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,10 @@ Installation
 
 ### Using Composer
 
+```shell
+composer require psecio/iniscan
 ```
-{
-    "require": {
-        "psecio/iniscan": "dev-master"
-    }
-}
-```
+
 
 The only current dependency is the Symfony console.
 
@@ -29,7 +26,7 @@ Additionally, you can install it outside of a project with the `global` function
 any directory you can use:
 
 ```
-$ ./composer.phar global require "psecio/iniscan=dev-master"
+$ ./composer.phar global require psecio/iniscan
 $ ~/.composer/vendor/bin/iniscan
 ```
 


### PR DESCRIPTION
Updated composer installation instructions.
It now follows the recommendation of using the "require" command and letting Composer auto-define the latest version.

```
$ composer global require psecio/iniscan
Using version ~3.6 for psecio/iniscan
```
