### PR TITLE
Corrected curl command to download the box installer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ ~/.composer/vendor/bin/iniscan
 
 First make sure you run composer.phar install
 ```
-curl -s http://box-project.org/installer.php | php
+curl -LSs http://box-project.org/installer.php | php
 php box.phar build
 ```
 This should result in a iniscan.phar file being created in the root folder.


### PR DESCRIPTION
I was not able to download the box.phar with the given curl command. The box project had a different curl command mentioned on their documentation page which I copied over.
