### PR TITLE
Mark session.save_path permissions check as N/A if running on Windows

### DIFF
--- a/src/Psecio/Iniscan/Rule/CheckSessionPath.php
+++ b/src/Psecio/Iniscan/Rule/CheckSessionPath.php
@@ -53,7 +53,7 @@ class CheckSessionPath extends \Psecio\Iniscan\Rule
 
 		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
 			$this->na();
-			$this->setDescription('Cannot check Windows permissions');
+			$this->setDescription('Cannot check Windows permissions. Please verify them manually');
 			return true;
 		}
 


### PR DESCRIPTION
The `fileperms` PHP command does not work correctly on Windows (always returns 777), so the check should be marked as not applicable.
