### PR TITLE
Output N/A status as warnings in HTML

### DIFF
--- a/src/Psecio/Iniscan/Command/ScanCommand/Output/Html.php
+++ b/src/Psecio/Iniscan/Command/ScanCommand/Output/Html.php
@@ -20,6 +20,10 @@ class Html extends \Psecio\Iniscan\Command\Output
 		foreach ($results as $result) {
 			$pass = ($result->getStatus() === true) ? 'pass' : 'fail';
 
+			if ($result->getStatus() === null) {
+				$pass = 'warn';
+			}
+
 			$resultHtml = '<div class="result '.$pass.'">';
 			$resultHtml .= '<table cellpadding="2" cellspacing="0" border="0" class="result">';
 			$resultHtml .= '<tr><td class="key">'.$result->getTestKey();


### PR DESCRIPTION
The HTML output displays not-applicable checks as errors because their status is `null`. The HTML template has CSS for a (unused?) `.warn` class. N/A items will now display as "warnings".
