### PR TITLE
Flip insecure expose_php & register_globals values

### DIFF
--- a/src/Psecio/Iniscan/rules.json
+++ b/src/Psecio/Iniscan/rules.json
@@ -170,7 +170,7 @@
 				"test": {
 					"key": "expose_php",
 					"operation": "notequals",
-					"value": "1"
+					"value": "0"
 				}
 			},
 			{
@@ -180,7 +180,7 @@
 				"test": {
 					"key": "register_globals",
 					"operation": "notequals",
-					"value": "1"
+					"value": "0"
 				}
 			},
 			{


### PR DESCRIPTION
When running `iniscan fix`, the suggested values for `expose_php` & `register_globals` are incorrect.
I'm not a security expert, but I believe the consensus on these values is that they should always be turned off.