### PR TITLE
Added display of current setting value

### DIFF
--- a/src/Psecio/Iniscan/Command/ScanCommand/Output/Console.php
+++ b/src/Psecio/Iniscan/Command/ScanCommand/Output/Console.php
@@ -4,6 +4,9 @@ namespace Psecio\Iniscan\Command\ScanCommand\Output;
 
 class Console extends \Psecio\Iniscan\Command\Output
 {
+    /**
+     * @param \Psecio\Iniscan\Rule[] $results
+     */
     public function render($results)
     {
         $output = $this->getOutput();
@@ -20,6 +23,7 @@ class Console extends \Psecio\Iniscan\Command\Output
             str_pad("Status", 7, ' ').'| '
             .str_pad("Severity", 9, ' ').'| '
             .str_pad("PHP Version", 12, ' ').'| '
+            .str_pad("Current Value", 14, ' ').'| '
             .str_pad("Key", 25, ' ').'| Description'
         );
         $output->writeLn(str_repeat('-', 70));
@@ -49,15 +53,18 @@ class Console extends \Psecio\Iniscan\Command\Output
             if ($failOnly === true && $status !== 'FAIL') {
                 continue;
             }
+
             $test = $result->getTest();
             $version = (isset($test->version)) ? $test->version : '';
             $test = (isset($test->key)) ? $test->key : '';
+            $value = $result->getValue();
 
             $output->writeLn(
                 '<fg='.$fgcolor.';bg='.$bgcolor.'>'
                 .str_pad($status, 7, ' ')
                 .'| '.str_pad($result->getLevel(), 9, ' ')
                 .'| '.str_pad($version, 12, ' ')
+                .'| '.str_pad($value, 14, ' ')
                 .'| '.str_pad($test, 25, ' ')
                 .'| '.$result->getDescription()
                 .'</fg='.$fgcolor.';bg='.$bgcolor.'>'

--- a/src/Psecio/Iniscan/Command/ScanCommand/Output/Html.php
+++ b/src/Psecio/Iniscan/Command/ScanCommand/Output/Html.php
@@ -4,6 +4,9 @@ namespace Psecio\Iniscan\Command\ScanCommand\Output;
 
 class Html extends \Psecio\Iniscan\Command\Output
 {
+    /**
+     * @param \Psecio\Iniscan\Rule[] $results
+     */
     public function render($results)
     {
         $output = $this->getOutput();

--- a/src/Psecio/Iniscan/Command/ScanCommand/Output/Json.php
+++ b/src/Psecio/Iniscan/Command/ScanCommand/Output/Json.php
@@ -4,6 +4,9 @@ namespace Psecio\Iniscan\Command\ScanCommand\Output;
 
 class Json extends \Psecio\Iniscan\Command\Output
 {
+    /**
+     * @param \Psecio\Iniscan\Rule[] $results
+     */
     public function render($results)
     {
         $output = $this->getOutput();

--- a/src/Psecio/Iniscan/Command/ScanCommand/Output/Xml.php
+++ b/src/Psecio/Iniscan/Command/ScanCommand/Output/Xml.php
@@ -4,6 +4,9 @@ namespace Psecio\Iniscan\Command\ScanCommand\Output;
 
 class Xml extends \Psecio\Iniscan\Command\Output
 {
+    /**
+     * @param \Psecio\Iniscan\Rule[] $results
+     */
     public function render($results)
     {
         $output = $this->getOutput();

--- a/src/Psecio/Iniscan/Rule.php
+++ b/src/Psecio/Iniscan/Rule.php
@@ -47,6 +47,12 @@ class Rule
 	private $version;
 
 	/**
+	 * The current value of the setting
+	 * @var string
+	 */
+	private $value = '[not set]';
+
+	/**
 	 * Current Cast instance
 	 * @var \Psecio\Iniscan\Cast
 	 */
@@ -179,6 +185,22 @@ class Rule
 	}
 
 	/**
+	 * @return string
+	 */
+	public function getValue()
+	{
+	    return $this->value;
+	}
+
+	/**
+	 * @param string $value
+	 */
+	public function setValue($value)
+	{
+	    $this->value = $value;
+	}
+
+	/**
 	 * Set the pass/fail status for the rule
 	 *
 	 * @param boolean $flag Pass/fail status
@@ -302,7 +324,8 @@ class Rule
 			'name' => $this->name,
 			'description' => $this->description,
 			'level' => $this->level,
-			'status' => $this->status
+			'status' => $this->status,
+			'currentValue' => $this->value,
 		);
 	}
 
@@ -344,6 +367,8 @@ class Rule
 			throw new \InvalidArgumentException('Invalid operation "'.$test->operation.'"');
 		}
 		$value = (isset($test->value)) ? $test->value : null;
+		$this->setValue($value);
+
 		$evalInstance = new $evalClass($this->getSection());
 
 		if (isset($test->version) && !$this->isVersion($test->version)) {


### PR DESCRIPTION
It would be helpful to see the current setting's value in the `scan` output.

I'd also like to submit a PR which will show the comparison operators against the predefined suggestions, which will make it clear which settings violated the rules, and why. Thoughts @enygma?

Also, you're evil for using tabs :stuck_out_tongue: 