### PR TITLE
Fix for RuleTest::testEvaluationNa on PHP >= 5.5.16

### DIFF
--- a/tests/Psecio/Iniscan/RuleTest.php
+++ b/tests/Psecio/Iniscan/RuleTest.php
@@ -301,7 +301,7 @@ class RuleTest extends \PHPUnit_Framework_TestCase
             'key' => 'foo',
             'operation' => 'equals',
             'value' => '1',
-            'version' => '5.6.12'
+            'version' => '8.1.2'
         );
         $ini = array(
             'PHP' => array(
@@ -311,7 +311,7 @@ class RuleTest extends \PHPUnit_Framework_TestCase
         $rule = new Rule(array(), 'PHP');
         $rule->setTest($test);
 
-        $result = $rule->evaluate($ini);
+        $rule->evaluate($ini);
         $this->assertNull($rule->getStatus());
     }
 


### PR DESCRIPTION
This test did not pass on PHP v5.6.13.
I set a ```version```, which will not be available in a near future.
We could think also, about getting current php version and incrementing its minor release number - just let me know.