### PR TITLE
Issue 89 - multiple open basedir directories support for upload_tmp_dir check test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/*
+bin/*

--- a/tests/Psecio/Iniscan/Rule/CheckUploadTmpDirTest.php
+++ b/tests/Psecio/Iniscan/Rule/CheckUploadTmpDirTest.php
@@ -9,7 +9,7 @@ class CheckUploadTmpDirTest extends \PHPUnit_Framework_TestCase
      *
      * @covers \Psecio\Iniscan\Rule\CheckUploadTmpDir::evaluate
      */
-/*    public function testUploadTmpDirFail()
+    public function testUploadTmpDirNotInOpenBaseDir()
     {
         $config = array();
         $section = 'PHP';
@@ -45,11 +45,11 @@ class CheckUploadTmpDirTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test that when upload_tmp_dir is inside open_basedir, we evaluate true
+     * Test that when open_basedir is set to system tmp dir and upload_tmp_dir is not set, we evaluate true
      *
      * @covers \Psecio\Iniscan\Rule\CheckUploadTmpDir::evaluate
      */
-/*    public function testUploadTmpDirSysDefault()
+    public function testUploadTmpDirSysDefault()
     {
         $config = array();
         $section = 'PHP';
@@ -61,5 +61,5 @@ class CheckUploadTmpDirTest extends \PHPUnit_Framework_TestCase
 
         $result = $rule->evaluate($ini);
         $this->assertTrue($result);
-    }*/
+    }
 }

--- a/tests/Psecio/Iniscan/Rule/CheckUploadTmpDirTest.php
+++ b/tests/Psecio/Iniscan/Rule/CheckUploadTmpDirTest.php
@@ -62,4 +62,45 @@ class CheckUploadTmpDirTest extends \PHPUnit_Framework_TestCase
         $result = $rule->evaluate($ini);
         $this->assertTrue($result);
     }
+
+    /**
+     * Test that when upload_tmp_dir is inside one of open_basedir directories, we evaluate true
+     *
+     * @covers \Psecio\Iniscan\Rule\CheckUploadTmpDir::evaluate
+     */
+    public function testUploadTmpDirInOneOfOpenBasedir()
+    {
+        $config = array();
+        $section = 'PHP';
+        $rule = new CheckUploadTmpDir($config, $section);
+
+        $ini = array(
+            'open_basedir' => '/tmp' . PATH_SEPARATOR . '/var',
+            'upload_tmp_dir' => '/tmp'
+        );
+
+        $result = $rule->evaluate($ini);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test that when upload_tmp_dir is not inside one of open_basedir directories, we evaluate false
+     *
+     * @covers \Psecio\Iniscan\Rule\CheckUploadTmpDir::evaluate
+     */
+    public function testUploadTmpDirNotInOneOfOpenBasedir()
+    {
+        $config = array();
+        $section = 'PHP';
+        $rule = new CheckUploadTmpDir($config, $section);
+
+        $ini = array(
+            'open_basedir' => '/tmp' . PATH_SEPARATOR . '/var',
+            'upload_tmp_dir' => '/etc'
+        );
+
+        $result = $rule->evaluate($ini);
+        $this->assertFalse($result);
+    }
+
 }


### PR DESCRIPTION
Hi @enygma!
I would be grateful for your opinion about my changes. 

They are not final - I will be doing refactoring tomorrowor or during this weekend, but your early feedback will be priceless for me. 
Additionally I have uncommented two tests from ```CheckUploadTmpDirTest``` which where there before. I had found them useful and I restored them.

Please, have a look at tests, class and used spelling. I'm not native and I'm counting on constructive feedback from you :)

After that I will take care of ```CheckSoapWsdlCacheDir``` class, but it will be a separate PR.