### PR TITLE
isVersion didn't respecting the version passed by the --php=? CLI option

### DIFF
--- a/src/Psecio/Iniscan/Rule.php
+++ b/src/Psecio/Iniscan/Rule.php
@@ -171,7 +171,7 @@ class Rule
 	 */
 	public function getVersion()
 	{
-		return $this->version;
+		return $this->version ?: PHP_VERSION;
 	}
 
 	/**
@@ -387,9 +387,7 @@ class Rule
 	 */
 	public function isVersion($phpVersion)
 	{
-		$currentVersion = $this->getVersion() ?: PHP_VERSION;
-		//$currentVersion = PHP_VERSION;
-		$compare = version_compare($currentVersion, $phpVersion);
+		$compare = version_compare($this->getVersion(), $phpVersion);
 		return ($compare === 1 || $compare === 0) ? true : false;
 	}
 

--- a/src/Psecio/Iniscan/Rule.php
+++ b/src/Psecio/Iniscan/Rule.php
@@ -387,7 +387,9 @@ class Rule
 	 */
 	public function isVersion($phpVersion)
 	{
-		$compare = version_compare(PHP_VERSION, $phpVersion);
+		$currentVersion = $this->getVersion() ?: PHP_VERSION;
+		//$currentVersion = PHP_VERSION;
+		$compare = version_compare($currentVersion, $phpVersion);
 		return ($compare === 1 || $compare === 0) ? true : false;
 	}
 

--- a/tests/Psecio/Iniscan/RuleTest.php
+++ b/tests/Psecio/Iniscan/RuleTest.php
@@ -428,8 +428,24 @@ class RuleTest extends \PHPUnit_Framework_TestCase
     {
         // a very old PHP release...please tell me you're not using it
         $phpVersion = '3.0';
-
         $rule = new Rule(array(), 'testing');
+
+        // Assume we're using 5.6 for now
+        $rule->setVersion('5.6');
+        // 5.6 > 3.0, so we get true
+        $this->assertTrue(
+            $rule->isVersion($phpVersion)
+        );
+
+        // Newer flavourful versions
+        $phpVersion = '7.0';
+        // 5.6 < 7.0, so we get false
+        $this->assertNotTrue(
+            $rule->isVersion($phpVersion)
+        );
+
+        // Update to 7.0 and we should get true
+        $rule->setVersion($phpVersion);
         $this->assertTrue(
             $rule->isVersion($phpVersion)
         );
@@ -443,10 +459,13 @@ class RuleTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetSetVersion()
     {
-        $version = 1;
+        $version = '1.0';
         $rule = new Rule(array(), 'testing');
         $rule->setVersion($version);
         $this->assertEquals($rule->getVersion(), $version);
+
+        $rule->setVersion('7.0');
+        $this->assertNotEquals($rule->getVersion(), $version);
     }
 
     /**

--- a/tests/Psecio/Iniscan/RuleTest.php
+++ b/tests/Psecio/Iniscan/RuleTest.php
@@ -430,6 +430,11 @@ class RuleTest extends \PHPUnit_Framework_TestCase
         $phpVersion = '3.0';
         $rule = new Rule(array(), 'testing');
 
+        // Ensure that the running version is fine
+        $this->assertTrue(
+            $rule->isVersion($phpVersion)
+        );
+
         // Assume we're using 5.6 for now
         $rule->setVersion('5.6');
         // 5.6 > 3.0, so we get true
@@ -441,12 +446,6 @@ class RuleTest extends \PHPUnit_Framework_TestCase
         $phpVersion = '7.0';
         // 5.6 < 7.0, so we get false
         $this->assertNotTrue(
-            $rule->isVersion($phpVersion)
-        );
-
-        // Update to 7.0 and we should get true
-        $rule->setVersion($phpVersion);
-        $this->assertTrue(
             $rule->isVersion($phpVersion)
         );
     }


### PR DESCRIPTION
isVersion() should use the getVersion() method to get the version and not use PHP_VERSION directly.