### PR TITLE
Exit with a correct exit code when outputting to the console

### DIFF
--- a/src/Psecio/Iniscan/Command/ScanCommand/Output/Console.php
+++ b/src/Psecio/Iniscan/Command/ScanCommand/Output/Console.php
@@ -98,6 +98,6 @@ class Console extends \Psecio\Iniscan\Command\Output
                 ."as they will be removed from future PHP versions.\n");
         }
 
-        return (count($fail) > 0) ? 1 : 0;
+        return intval($fail > 0);
     }
 }


### PR DESCRIPTION
Running the `scan` command and outputting the result to console would always exit with an exit code of `1` regardless of whether there were any errors found or not.

This messes up CI builds and other usages where the exit code is meaningful.

The bug was caused by invalid assumption in the result value of `Output\Console::render`: the `$fail` variable is an integer, not an array.

The following illustrates the previous situation and how using `count` always resulted in the exit code of `1`.

``` php
php > $fail = 0;
php > var_dump((count($fail) > 0) ? 1 : 0);
int(1)
php > $fail = 1;
php > var_dump((count($fail) > 0) ? 1 : 0);
int(1)
```

This patch fixes the bug; `Output\Console::render` now treats the `$fail` variable as an integer and returns a correct exit status.
