### PR TITLE
Corrected session.lazy_write warning text

### DIFF
--- a/src/Psecio/Iniscan/rules.json
+++ b/src/Psecio/Iniscan/rules.json
@@ -117,7 +117,7 @@
 			},
 			{
 				"name": "Lazy session writing is enabled",
-				"description": "Lazy session writes only when the session data if it has been modified. This should be enabled to prevent potential information exposure.",
+				"description": "Lazy session writes only when the session data has been modified. This should be enabled to prevent potential information exposure.",
 				"level": "WARNING",
 				"test": {
 					"key": "session.lazy_write",


### PR DESCRIPTION
The warning message didn't read quite right, just making a quick fix