### PR TITLE
Option for a non-dynamic HTML output filename / make html filename configurable

### DIFF
--- a/src/Psecio/Iniscan/Command/ScanCommand/Output/Html.php
+++ b/src/Psecio/Iniscan/Command/ScanCommand/Output/Html.php
@@ -9,26 +9,12 @@ class Html extends \Psecio\Iniscan\Command\Output
 	 */
 	public function render($results)
 	{
-		$output = $this->getOption('output');
-
-		$outputDir = dirname($output);
-		$outputFilename = basename($output);
-
-		// Find out if a filename has been given in the output argument. If not, create the default output filename.
-		// this checks for *.htm*
-		if (strpos($outputFilename, ".htm") === FALSE) {
-			// To keep backward compatibility, use the value of
-			//the given output argument as the directory name.
-			$outputDir = $output;
-			$outputFilename = 'iniscan-output-'.date('Ymd').'.html';
-		}
+		$outputFilePath = $this->getOutputFilename($this->getOption('output'));
 
 		// Check if the configured output directory exists. If not, create it.
-		if (!is_dir($outputDir)) {
-			mkdir($outputDir, 0777, true);
+		if (!is_dir(dirname($outputFilePath))) {
+			mkdir(dirname($outputFilePath), 0777, true);
 		}
-
-		$outputFilePath = $outputDir . DIRECTORY_SEPARATOR . $outputFilename;
 
 		// read in the template file
 		$template = file_get_contents(__DIR__.'/../Templates/html.html');
@@ -54,11 +40,52 @@ class Html extends \Psecio\Iniscan\Command\Output
 			$values['results'] .= $resultHtml;
 		}
 
-		if (is_writable($outputDir)) {
+		if (is_writable(dirname($outputFilePath))) {
 			foreach ($values as $key => $value) {
 				$template = str_replace('{{'.$key.'}}', $value, $template);
 			}
 			file_put_contents($outputFilePath, $template);
 		}
+	}
+
+	/**
+	 * Returns path and filename for the output file.
+	 * @param $output The output path configured via its argument
+	 */
+	public function getOutputFilename($output)
+	{
+		// default behaviour / backwards compatibility
+		$outputDir = $output;
+		$outputFilename = $this->getDefaultOutputFilename();
+
+		// Find out if a .htm(l) filename has been given in the output argument.
+		if ($this->endsWith($output, ".htm") || $this->endsWith($output, ".html")) {
+			$outputDir = dirname($output);
+			$outputFilename = basename($output);
+		}
+
+		return $outputDir . DIRECTORY_SEPARATOR . $outputFilename;
+	}
+
+	public function getDefaultOutputFilename()
+	{
+		return 'iniscan-output-'.date('Ymd').'.html';
+	}
+
+	/**
+	 * Return true if $haystack ends with $needle.
+	 * Source: http://stackoverflow.com/a/834355
+	 * @param $haystack
+	 * @param $needle
+	 * @return bool
+	 */
+	private function endsWith($haystack, $needle)
+	{
+		$length = strlen($needle);
+		if ($length == 0) {
+			return true;
+		}
+
+		return (substr($haystack, -$length) === $needle);
 	}
 }

--- a/src/Psecio/Iniscan/Command/ScanCommand/Output/Html.php
+++ b/src/Psecio/Iniscan/Command/ScanCommand/Output/Html.php
@@ -4,13 +4,31 @@ namespace Psecio\Iniscan\Command\ScanCommand\Output;
 
 class Html extends \Psecio\Iniscan\Command\Output
 {
-    /**
-     * @param \Psecio\Iniscan\Rule[] $results
-     */
-    public function render($results)
-    {
-        $output = $this->getOutput();
+	/**
+	 * @param \Psecio\Iniscan\Rule[] $results
+	 */
+	public function render($results)
+	{
 		$output = $this->getOption('output');
+
+		$outputDir = dirname($output);
+		$outputFilename = basename($output);
+
+		// Find out if a filename has been given in the output argument. If not, create the default output filename.
+		// this checks for *.htm*
+		if (strpos($outputFilename, ".htm") === FALSE) {
+			// To keep backward compatibility, use the value of
+			//the given output argument as the directory name.
+			$outputDir = $output;
+			$outputFilename = 'iniscan-output-'.date('Ymd').'.html';
+		}
+
+		// Check if the configured output directory exists. If not, create it.
+		if (!is_dir($outputDir)) {
+			mkdir($outputDir, 0777, true);
+		}
+
+		$outputFilePath = $outputDir . DIRECTORY_SEPARATOR . $outputFilename;
 
 		// read in the template file
 		$template = file_get_contents(__DIR__.'/../Templates/html.html');
@@ -24,7 +42,7 @@ class Html extends \Psecio\Iniscan\Command\Output
 			$pass = ($result->getStatus() === true) ? 'pass' : 'fail';
 
 			if ($result->getStatus() === null) {
-				$pass = 'warn';
+			    $pass = 'warn';
 			}
 
 			$resultHtml = '<div class="result '.$pass.'">';
@@ -36,12 +54,11 @@ class Html extends \Psecio\Iniscan\Command\Output
 			$values['results'] .= $resultHtml;
 		}
 
-		if (is_writable($output)) {
-			$output .= '/iniscan-output-'.date('Ymd').'.html';
+		if (is_writable($outputDir)) {
 			foreach ($values as $key => $value) {
 				$template = str_replace('{{'.$key.'}}', $value, $template);
 			}
-			file_put_contents($output, $template);
+			file_put_contents($outputFilePath, $template);
 		}
 	}
 }

--- a/tests/Psecio/Iniscan/Command/ScanCommand/Output/HtmlTest.php
+++ b/tests/Psecio/Iniscan/Command/ScanCommand/Output/HtmlTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: akatzig
+ * Date: 20/02/2017
+ * Time: 15:05
+ */
+
+namespace Psecio\Iniscan\Operation\ScanCommand\Output;
+
+
+use Psecio\Iniscan\Command\ScanCommand\Output\Html;
+
+class HtmlTest extends \PHPUnit_Framework_TestCase
+{
+	private $htmlOutput;
+	private $defaultOutputFilename;
+
+	public function setUp()
+	{
+		$outputInterfaceMock = $this->getMockBuilder(\Symfony\Component\Console\Output\OutputInterface::class)->getMock();
+		$this->htmlOutput = new Html($outputInterfaceMock, null);
+		$this->defaultOutputFilename = $this->htmlOutput->getDefaultOutputFilename();
+	}
+
+	/**
+	 * Tests if the output file name is correctly recognized and generated.
+	 */
+	public function testOutputFilename()
+	{
+		$generatedFile = DIRECTORY_SEPARATOR . $this->defaultOutputFilename;
+
+		$testValues = array(
+			"/var/outputfolder" => "/var/outputfolder" . $generatedFile,
+			"/folder/folder.ext" => "/folder/folder.ext" . $generatedFile,
+			"/folder/folder.ext/abcde" => "/folder/folder.ext/abcde" . $generatedFile,
+			"./folder/folder.ext/abcde..." => "./folder/folder.ext/abcde..." . $generatedFile,
+			"/folder/folder.ext/filenamehtml" => "/folder/folder.ext/filenamehtml" . $generatedFile,
+			"./folder/folder.ext/123.ehtml" => "./folder/folder.ext/123.ehtml" . $generatedFile,
+			"../folder/folder.ext/123.html.a" => "../folder/folder.ext/123.html.a" . $generatedFile,
+			"folder/folder.ext/123.html.a" => "folder/folder.ext/123.html.a" . $generatedFile,
+			"folder/abc/1.ht" => "folder/abc/1.ht" . $generatedFile,
+			"../folder/folder.ext/123.html" => "../folder/folder.ext/123.html",
+			"/folder/folder.ext/123.abc.html" => "/folder/folder.ext/123.abc.html",
+			"/folder/folder.ext/123.abc.htm" => "/folder/folder.ext/123.abc.htm",
+			"/folder/abc/1.htm" => "/folder/abc/1.htm",
+			"folder/abc/1.htm" => "folder/abc/1.htm"
+		);
+
+		foreach($testValues as $input => $expectedOutput) {
+			$output = $this->htmlOutput->getOutputFilename($input);
+			$this->assertSame($expectedOutput, $output);
+		}
+
+	}
+}


### PR DESCRIPTION
- Adding the possibility to define a filename for generated HTML files via the '--output' argument. If it contains a ".htm*" extension, the given output filename will be used. This way it can be statically referenced, e.g. in CI.

- Create the defined output folder for HTML format if it doesn't exist.

See https://github.com/psecio/iniscan/issues/105