### PR TITLE
Fix false positive in soap.wsdl_cache_dir test

### DIFF
--- a/src/Psecio/Iniscan/Rule/CheckSoapWsdlCacheDir.php
+++ b/src/Psecio/Iniscan/Rule/CheckSoapWsdlCacheDir.php
@@ -49,7 +49,7 @@ class CheckSoapWsdlCacheDir extends \Psecio\Iniscan\Rule
 			return false;
 		}
 
-		if (strpos($wsdlCacheDir, '/tmp') !== false)
+		if (preg_match('/\/tmp$/', $wsdlCacheDir))
 		{
 			$this->setDescription('The SOAP WSDL cache directory is inside of "/tmp/" which allows local users to conduct WSDL injection attacks (CVE-2013-6501)');
 			$this->fail();


### PR DESCRIPTION
- We're now testing if the string is exactly '/tmp' instead of checking
  if there's any '/tmp' in it;