### PR TITLE
Fix show command for PHP >= 7.0.0

### DIFF
--- a/src/Psecio/Iniscan/Command/ShowCommand.php
+++ b/src/Psecio/Iniscan/Command/ShowCommand.php
@@ -40,6 +40,20 @@ class ShowCommand extends Command
         if (!is_file($path)) {
             throw new \Exception('Path is null or not accessible: "'.$path.'"');
         }
+
+        $this->showIni($output, $path);
+    }
+
+    /**
+     * Read an INI file and display each of it's configuration
+     *
+     * @param OutputInterface $output Output object
+     * @param string          $path   The path to the ini file
+     *
+     * @return null
+     */
+    protected function showIni(OutputInterface $output, $path)
+    {
         $ini = parse_ini_file($path, true);
 
         $output->writeLn('Current PHP.ini settings from '.$path);
@@ -47,15 +61,31 @@ class ShowCommand extends Command
 
         foreach ($ini as $section => $data) {
             $output->writeLn('<info>:: '.$section.'</info>');
-            if (empty($data)) {
-                $output->writeLn("\t<fg=yellow>No settings</fg=yellow>");
-            } else {
-                foreach ($data as $path => $value) {
-                    $output->writeLn("\t".$path.' => '.var_export($value, true));
-                }
-            }
+            $this->showSection($output, $data);
             $output->writeLn("-----------------\n");
         }
 
+    }
+
+    /**
+     * Display a section from the INI file
+     *
+     * @param OutputInterface $output Output object
+     * @param mixed           $data   The content of the section
+     *
+     * @return null
+     */
+    protected function showSection(OutputInterface $output, $data)
+    {
+        if (empty($data)) {
+            $output->writeLn("\t<fg=yellow>No settings</fg=yellow>");
+            return;
+        } else if (is_array($data)) {
+            foreach ($data as $path => $value) {
+                $output->writeLn("\t".$path.' => '.var_export($value, true));
+            }
+            return;
+        }
+        $output->writeLn("\t" . var_export($data, true));
     }
 }


### PR DESCRIPTION
- Implemented the methods showIni and showSection;
- The showIni can display data if it's empty, an array or only a value;
- It's important to note that this code rely on the process_sections
  argument from the parse_ini_file function and this processing is
  somehow weak, because it depends on the existence of the '[SECTION_NAME]'
  and the 'section_name.' is not interpreted as a section;