### PR TITLE
Fix for PHP 7.2

### DIFF
--- a/src/Psecio/Iniscan/Command/ScanCommand/Output/Console.php
+++ b/src/Psecio/Iniscan/Command/ScanCommand/Output/Console.php
@@ -98,6 +98,6 @@ class Console extends \Psecio\Iniscan\Command\Output
                 ."as they will be removed from future PHP versions.\n");
         }
 
-        return (count($fail) > 0) ? 1 : 0;
+        return ($fail > 0) ? 1 : 0;
     }
 }


### PR DESCRIPTION
Only count iterables (not integers).

As far as I can tell, `$fail` will only ever be an integer, not an array.